### PR TITLE
Cut release v1.0.2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Publish Code Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: /home/runner/work/markdown-colorcode/markdown-colorcode/coverage.opencover.xml
+        files: /home/runner/work/markdown-colorcode/markdown-colorcode/tests/Markdown.ColorCode.UnitTests/coverage.json
         fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-12-09
+
+### Changed
+
+- ColorCode.Core `v2.0.13` => `v2.0.14`
+- ColorCode.HTML `v2.0.13` => `v2.0.14`
+
 ## [1.0.1] - 2022-03-19
 
 ### Changed

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -7,7 +7,7 @@
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>1.0.1</Version>
+	<Version>1.0.2</Version>
 	<Authors>William Baldoumas</Authors>
 	<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
 	<Copyright>Copyright ©2022 William Baldoumas</Copyright>


### PR DESCRIPTION
## Description

Bumps to v1.0.2 to release with updated dependencies.

This addresses https://github.com/wbaldoumas/markdown-colorcode/issues/72.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
