### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-03-12
+
+### Changed
+
+- Markdig `v0.30.4` => `v0.31.0`
+
 ## [1.0.2] - 2022-12-09
 
 ### Changed

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -7,7 +7,7 @@
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>1.0.2</Version>
+	<Version>1.0.3</Version>
 	<Authors>William Baldoumas</Authors>
 	<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
 	<Copyright>Copyright ©2022 William Baldoumas</Copyright>


### PR DESCRIPTION
## Description

Release `v1.0.3`, bringing Markdig from `v0.30.4` to `v0.31.0`.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - dependency updates

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
