### PR TITLE
Support CSS Class Styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+[*]
+insert_final_newline = true
+
 [*.cs]
 
 # parantheses formatting

--- a/src/Markdown.ColorCode/ColorCodeBlockRenderer.cs
+++ b/src/Markdown.ColorCode/ColorCodeBlockRenderer.cs
@@ -16,16 +16,22 @@ public class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
 {
     private readonly CodeBlockRenderer _underlyingCodeBlockRenderer;
     private readonly StyleDictionary _styleDictionary;
+    private readonly bool _useCssFormatter;
 
     /// <summary>
     ///     Create a new <see cref="ColorCodeBlockRenderer"/> with the specified <paramref name="underlyingCodeBlockRenderer"/> and <paramref name="styleDictionary"/>.
     /// </summary>
     /// <param name="underlyingCodeBlockRenderer">The underlying CodeBlockRenderer to handle unsupported languages.</param>
     /// <param name="styleDictionary">A StyleDictionary for custom styling.</param>
-    public ColorCodeBlockRenderer(CodeBlockRenderer underlyingCodeBlockRenderer, StyleDictionary styleDictionary)
+    /// <param name="useCssFormatter">Indicates whether to use the CSS formatter.</param>
+    public ColorCodeBlockRenderer(
+        CodeBlockRenderer underlyingCodeBlockRenderer,
+        StyleDictionary styleDictionary,
+        bool useCssFormatter = false)
     {
         _underlyingCodeBlockRenderer = underlyingCodeBlockRenderer;
         _styleDictionary = styleDictionary;
+        _useCssFormatter = useCssFormatter;
     }
 
     /// <summary>
@@ -53,8 +59,7 @@ public class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
         }
 
         var code = ExtractCode(codeBlock);
-        var formatter = new HtmlFormatter(_styleDictionary);
-        var html = formatter.GetHtmlString(code, language);
+        var html = GetHtml(code, language);
 
         renderer.Write(html);
     }
@@ -94,4 +99,8 @@ public class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
 
         return code.ToString();
     }
+
+    private string? GetHtml(string sourceCode, ILanguage language) => _useCssFormatter
+        ? new HtmlClassFormatter(_styleDictionary).GetHtmlString(sourceCode, language)
+        : new HtmlFormatter(_styleDictionary).GetHtmlString(sourceCode, language);
 }

--- a/src/Markdown.ColorCode/ColorCodeExtension.cs
+++ b/src/Markdown.ColorCode/ColorCodeExtension.cs
@@ -11,12 +11,18 @@ namespace Markdown.ColorCode;
 public class ColorCodeExtension : IMarkdownExtension
 {
     private readonly StyleDictionary _styleDictionary;
+    private readonly bool _useCssFormatter;
 
     /// <summary>
     ///     Creates a new <see cref="ColorCodeExtension"/> with the specified <paramref name="styleDictionary"/>.
     /// </summary>
     /// <param name="styleDictionary">A dictionary indicating how to style the code.</param>
-    public ColorCodeExtension(StyleDictionary styleDictionary) => _styleDictionary = styleDictionary;
+    /// <param name="useCssFormatter">Indicates whether to use the CSS formatter.</param>
+    public ColorCodeExtension(StyleDictionary styleDictionary, bool useCssFormatter = false)
+    {
+        _styleDictionary = styleDictionary;
+        _useCssFormatter = useCssFormatter;
+    }
 
     /// <summary>
     ///     Sets up this extension for the specified pipeline.
@@ -52,7 +58,8 @@ public class ColorCodeExtension : IMarkdownExtension
         htmlRenderer.ObjectRenderers.AddIfNotAlready(
             new ColorCodeBlockRenderer(
                 codeBlockRenderer,
-                _styleDictionary
+                _styleDictionary,
+                _useCssFormatter
             )
         );
     }

--- a/src/Markdown.ColorCode/MarkdownPipelineBuilderExtensions.cs
+++ b/src/Markdown.ColorCode/MarkdownPipelineBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Markdown.ColorCode;
 public static class MarkdownPipelineBuilderExtensions
 {
     /// <summary>
-    ///     Use ColorCode to apply code colorization to markdown within the Markdig pipeline.
+    ///     Use ColorCode to apply code colorization to markdown using inline style attributes within the Markdig pipeline.
     /// </summary>
     /// <param name="pipeline">The pipeline the ColorCode extension is being added to.</param>
     /// <param name="styleDictionary">An optional StyleDictionary for custom styling.</param>
@@ -19,6 +19,21 @@ public static class MarkdownPipelineBuilderExtensions
         StyleDictionary? styleDictionary = null)
     {
         pipeline.Extensions.Add(new ColorCodeExtension(styleDictionary ?? StyleDictionary.DefaultDark));
+
+        return pipeline;
+    }
+
+    /// <summary>
+    ///     Use ColorCode to apply code colorization to markdown using CSS classes within the Markdig pipeline.
+    /// </summary>
+    /// <param name="pipeline">The pipeline the ColorCode extension is being added to.</param>
+    /// <param name="styleDictionary">An optional StyleDictionary for custom styling.</param>
+    /// <returns>The MarkdownPipelineBuilder with the added ColorCode extension.</returns>
+    public static MarkdownPipelineBuilder UseColorCodeWithClassStyling(
+        this MarkdownPipelineBuilder pipeline,
+        StyleDictionary? styleDictionary = null)
+    {
+        pipeline.Extensions.Add(new ColorCodeExtension(styleDictionary ?? StyleDictionary.DefaultDark, true));
 
         return pipeline;
     }

--- a/tests/Markdown.ColorCode.UnitTests/ColorCodeBlockRendererTests.cs
+++ b/tests/Markdown.ColorCode.UnitTests/ColorCodeBlockRendererTests.cs
@@ -116,6 +116,11 @@ That was some **code**.
         .UseColorCode()
         .Build();
 
+    private readonly MarkdownPipeline _cssPipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .UseColorCodeWithClassStyling()
+        .Build();
+
     [Test]
     [TestCase(MarkdownWithEmptyFencedCodeBlock, false)]
     [TestCase(MarkdownWithEmptyFencedCodeBlockInline, true)]
@@ -147,6 +152,37 @@ That was some **code**.
     }
 
     [Test]
+    [TestCase(MarkdownWithEmptyFencedCodeBlock, "", false)]
+    [TestCase(MarkdownWithEmptyFencedCodeBlockInline, "cplusplus", true)]
+    [TestCase(MarkdownWithEmptyFencedCodeBlockAndLanguage, "csharp", true)]
+    [TestCase(MarkdownWithEmptyClosedFencedCodeBlockAndLanguage, "csharp", true)]
+    public void When_markdown_with_empty_fenced_code_block_is_passed_to_css_pipeline_valid_html_is_generated(
+        string markdown,
+        string languageClass,
+        bool isStyled)
+    {
+        // act
+        var html = Markdig.Markdown.ToHtml(markdown, _cssPipeline);
+
+        // assert
+        html.Should().NotBeNull("because an html string was properly generated");
+
+        var htmlDocument = new HtmlDocument();
+
+        htmlDocument.LoadHtml(html);
+        htmlDocument.ParseErrors.Should().BeEmpty("because valid html was generated");
+
+        if (isStyled)
+        {
+            html.Should().ContainAll("pre", "div", $"class=\"{languageClass}\"");
+        }
+        else
+        {
+            html.Should().ContainAll("pre", "code");
+        }
+    }
+
+    [Test]
     public void When_markdown_with_specified_language_is_passed_valid_html_is_generated()
     {
         // act
@@ -164,10 +200,28 @@ That was some **code**.
     }
 
     [Test]
+    public void When_markdown_with_specified_language_is_passed_to_css_pipeline_valid_html_is_generated()
+    {
+        // act
+        var html = Markdig.Markdown.ToHtml(MarkdownWithLanguage, _cssPipeline);
+
+        // assert
+        html.Should().NotBeNull("because an html string was properly generated");
+
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.LoadHtml(html);
+
+        htmlDocument.ParseErrors.Should().BeEmpty("because valid html was generated");
+
+        html.Should().ContainAll("div", "pre", "span", "class=\"csharp\"", "12345");
+    }
+
+    [Test]
     public void When_markdown_without_specified_language_is_passed_valid_html_is_generated()
     {
         // act
         var html = Markdig.Markdown.ToHtml(MarkdownWithoutLanguage, _pipeline);
+        var otherHtml = Markdig.Markdown.ToHtml(MarkdownWithoutLanguage, _cssPipeline);
 
         // assert
         html.Should().NotBeNull("because an html string was properly generated");
@@ -178,6 +232,7 @@ That was some **code**.
         htmlDocument.ParseErrors.Should().BeEmpty("because valid html was generated");
 
         html.Should().ContainAll("pre", "code", "12345");
+        otherHtml.Should().ContainAll("pre", "code", "12345");
     }
 
     [Test]
@@ -185,6 +240,7 @@ That was some **code**.
     {
         // act
         var html = Markdig.Markdown.ToHtml(MarkdownWithUnsupportedLanguage, _pipeline);
+        var otherHtml = Markdig.Markdown.ToHtml(MarkdownWithUnsupportedLanguage, _cssPipeline);
 
         // assert
         html.Should().NotBeNull("because an html string was properly generated");
@@ -194,7 +250,8 @@ That was some **code**.
 
         htmlDocument.ParseErrors.Should().BeEmpty("because valid html was generated");
 
-        html.Should().ContainAll("pre", "code", "capitalize");
+        html.Should().ContainAll("pre", "code", "capitalize", "class=\"language-elixir\"");
+        otherHtml.Should().ContainAll("pre", "code", "capitalize", "class=\"language-elixir\"");
     }
 
     [Test]


### PR DESCRIPTION
## Description

Support CSS class styling, rather than inline style attributes.

Addresses https://github.com/wbaldoumas/markdown-colorcode/issues/100.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
