### PR TITLE
Closes #106

### DIFF
--- a/src/Markdown.ColorCode/AssemblyInfo.cs
+++ b/src/Markdown.ColorCode/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo($"Markdown.ColorCode.UnitTests")]

--- a/src/Markdown.ColorCode/ColorCodeBlockRenderer.cs
+++ b/src/Markdown.ColorCode/ColorCodeBlockRenderer.cs
@@ -68,7 +68,12 @@ public class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
     {
         var languageId = fencedCodeBlock.Info!.Replace(parser.InfoPrefix!, string.Empty);
 
-        return string.IsNullOrWhiteSpace(languageId) ? null : Languages.FindById(languageId);
+        if (string.IsNullOrWhiteSpace(languageId) || languageId == TextLanguage.LanguageId)
+        {
+            return new TextLanguage();
+        }
+
+        return Languages.FindById(languageId);
     }
 
     private static string ExtractCode(LeafBlock leafBlock)

--- a/src/Markdown.ColorCode/TextLanguage.cs
+++ b/src/Markdown.ColorCode/TextLanguage.cs
@@ -1,0 +1,39 @@
+﻿using ColorCode;
+using ColorCode.Common;
+
+namespace Markdown.ColorCode;
+
+/// <summary>
+///     A language which does not provide any keywords
+/// </summary>
+internal sealed class TextLanguage : ILanguage
+{
+    /// <summary>
+    ///     Provides the <see cref="Id"/> of this language without requiring a reference to an instance
+    /// </summary>
+    internal const string LanguageId = "text";
+
+    /// <inheritdoc/>
+    public string CssClassName => LanguageId;
+
+    /// <inheritdoc/>
+    public string? FirstLinePattern => null;
+
+    /// <inheritdoc/>
+    public string Id => LanguageId;
+
+    /// <inheritdoc/>
+    public string Name => nameof(TextLanguage);
+
+    /// <inheritdoc/>
+    public IList<LanguageRule> Rules => new List<LanguageRule>(1)
+    {
+        new ("^$", new Dictionary<int, string>(1)
+        {
+            { 0, ScopeName.PlainText },
+        }),
+    };
+
+    /// <inheritdoc/>
+    public bool HasAlias(string lang) => true;
+}

--- a/tests/Markdown.ColorCode.UnitTests/ColorCodeBlockRendererTests.cs
+++ b/tests/Markdown.ColorCode.UnitTests/ColorCodeBlockRendererTests.cs
@@ -141,14 +141,7 @@ That was some **code**.
         htmlDocument.LoadHtml(html);
         htmlDocument.ParseErrors.Should().BeEmpty("because valid html was generated");
 
-        if (isStyled)
-        {
-            html.Should().ContainAll("pre", "div", "style=\"color");
-        }
-        else
-        {
-            html.Should().ContainAll("pre", "code");
-        }
+        html.Should().ContainAll("pre", "div", "style=\"color");
     }
 
     [Test]
@@ -178,7 +171,7 @@ That was some **code**.
         }
         else
         {
-            html.Should().ContainAll("pre", "code");
+            html.Should().ContainAll("pre", "div", $"class=\"{TextLanguage.LanguageId}\"");
         }
     }
 


### PR DESCRIPTION
## Description

Closes issue #106

Code blocks declared without any language or with `text` are now rendered as code blocks.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
