### PR TITLE
Test CsharpToColouredHTML

### DIFF
--- a/src/Markdown.ColorCode/HtmlFormatterType.cs
+++ b/src/Markdown.ColorCode/HtmlFormatterType.cs
@@ -13,5 +13,15 @@ public enum HtmlFormatterType
     /// <summary>
     ///     Use the ColorCode <see cref="HtmlClassFormatter"/> to format the code using CSS classes.
     /// </summary>
-    Css
+    Css,
+
+    /// <summary>
+    ///    Use the ColorCode <see cref="HtmlFormatter"/> to format the code using inline style attributes, boosted with CsharpToColouredHTML.Core.
+    /// </summary>
+    StyleWithCSharpToColoredHtml,
+
+    /// <summary>
+    ///    Use the ColorCode <see cref="HtmlClassFormatter"/> to format the code using CSS classes, boosted with CsharpToColouredHTML.Core.
+    /// </summary>
+    CssWithCSharpToColoredHtml
 }

--- a/src/Markdown.ColorCode/Internal/CSharpToColouredHtmlFormatter.cs
+++ b/src/Markdown.ColorCode/Internal/CSharpToColouredHtmlFormatter.cs
@@ -1,0 +1,22 @@
+﻿using ColorCode.Common;
+using CsharpToColouredHTML.Core;
+
+namespace Markdown.ColorCode.Internal;
+
+/// <inheritdoc cref="IHtmlFormatter"/>
+internal sealed class CSharpToColouredHtmlFormatter : IHtmlFormatter
+{
+    private readonly IHtmlFormatter _internalFormatter;
+
+    /// <summary>
+    ///     Create a new <see cref="CSharpToColouredHtmlFormatter"/>.
+    /// </summary>
+    /// <param name="internalFormatter">The internal formatter to use.</param>
+    public CSharpToColouredHtmlFormatter(IHtmlFormatter internalFormatter) => _internalFormatter = internalFormatter;
+
+    /// <inheritdoc />
+    public string? GetHtmlString(string sourceCode, ILanguage language) =>
+        language.Id == LanguageId.CSharp ?
+            new CsharpColourer().ProcessSourceCode(sourceCode, new HTMLEmitter(new HTMLEmitterSettings().DisableIframe().DisableLineNumbers())) :
+            _internalFormatter.GetHtmlString(sourceCode, language);
+}

--- a/src/Markdown.ColorCode/Internal/ColorCodeBlockRenderer.cs
+++ b/src/Markdown.ColorCode/Internal/ColorCodeBlockRenderer.cs
@@ -1,7 +1,4 @@
-﻿using ColorCode.Common;
-using CsharpToColouredHTML.Core;
-
-namespace Markdown.ColorCode.Internal;
+﻿namespace Markdown.ColorCode.Internal;
 
 /// <summary>
 ///     A renderer which colorizes code blocks using ColorCode.
@@ -57,10 +54,7 @@ internal sealed class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
         }
 
         var code = _codeExtractor.ExtractCode(codeBlock);
-
-        var html = language.Id == LanguageId.CSharp ?
-            new CsharpColourer().ProcessSourceCode(code, new HTMLEmitter(new HTMLEmitterSettings().DisableIframe().DisableLineNumbers())) :
-            _htmlFormatter.GetHtmlString(code, language);
+        var html = _htmlFormatter.GetHtmlString(code, language);
 
         renderer.Write(html);
     }

--- a/src/Markdown.ColorCode/Internal/ColorCodeBlockRenderer.cs
+++ b/src/Markdown.ColorCode/Internal/ColorCodeBlockRenderer.cs
@@ -1,4 +1,7 @@
-﻿namespace Markdown.ColorCode.Internal;
+﻿using ColorCode.Common;
+using CsharpToColouredHTML.Core;
+
+namespace Markdown.ColorCode.Internal;
 
 /// <summary>
 ///     A renderer which colorizes code blocks using ColorCode.
@@ -54,7 +57,10 @@ internal sealed class ColorCodeBlockRenderer : HtmlObjectRenderer<CodeBlock>
         }
 
         var code = _codeExtractor.ExtractCode(codeBlock);
-        var html = _htmlFormatter.GetHtmlString(code, language);
+
+        var html = language.Id == LanguageId.CSharp ?
+            new CsharpColourer().ProcessSourceCode(code, new HTMLEmitter(new HTMLEmitterSettings().DisableIframe().DisableLineNumbers())) :
+            _htmlFormatter.GetHtmlString(code, language);
 
         renderer.Write(html);
     }

--- a/src/Markdown.ColorCode/Internal/HtmlFormatterFactory.cs
+++ b/src/Markdown.ColorCode/Internal/HtmlFormatterFactory.cs
@@ -16,6 +16,8 @@ internal sealed class HtmlFormatterFactory : IHtmlFormatterFactory
     {
         HtmlFormatterType.Style => new HtmlStyleFormatter(_styleDictionary),
         HtmlFormatterType.Css => new HtmlCssFormatter(_styleDictionary),
+        HtmlFormatterType.StyleWithCSharpToColoredHtml => new CSharpToColouredHtmlFormatter(new HtmlStyleFormatter(_styleDictionary)),
+        HtmlFormatterType.CssWithCSharpToColoredHtml => new CSharpToColouredHtmlFormatter(new HtmlCssFormatter(_styleDictionary)),
         _ => throw new ArgumentOutOfRangeException(nameof(htmlFormatterType), htmlFormatterType, null)
     };
 }

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -7,7 +7,7 @@
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Authors>William Baldoumas</Authors>
 	<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
 	<Copyright>Copyright ©2022 William Baldoumas</Copyright>
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" Version="2.0.15" />
     <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
-	<PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41" />
+    <PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41" />
     <PackageReference Include="Markdig" Version="0.34.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -47,9 +47,7 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" Version="2.0.15" />
     <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
-    <PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41" />
     <PackageReference Include="Markdig" Version="0.34.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" Version="2.0.15" />
     <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
+	<PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41" />
     <PackageReference Include="Markdig" Version="0.34.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -47,7 +47,9 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" Version="2.0.15" />
     <PackageReference Include="ColorCode.HTML" Version="2.0.15" />
-    <PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41" />
+    <PackageReference Include="CsharpToColouredHTML.Core" Version="1.0.41">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Markdig" Version="0.34.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Markdown.ColorCode.UnitTests/Markdown.ColorCode.UnitTests.csproj
+++ b/tests/Markdown.ColorCode.UnitTests/Markdown.ColorCode.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Description

A test to see if leveraging `CsharpToColouredHTML` may improve syntax highlighting for C# code handled by this library.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
