### PR TITLE
v2.3.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.0] - 2024-07-16
 
-[ElderJames](https://github.com/ElderJames) made their first contribution! ??
+[ElderJames](https://github.com/ElderJames) made their first contribution! 🎉
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2024-07-16
+
+[ElderJames](https://github.com/ElderJames) made their first contribution! ??
+
+### Added
+
+- Added support for .NET Standard 2.0 in the core `Markdown.ColorCode` package.
+
 ## [2.2.2] - 2024-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ public interface FooService {
 ### Package Manager
 
 ```text
-Install-Package Markdown.ColorCode -Version 2.2.2
+Install-Package Markdown.ColorCode -Version 2.3.0
 ```
 
 ### .NET CLI
 
 ```text
-dotnet add package Markdown.ColorCode --version 2.2.2
+dotnet add package Markdown.ColorCode --version 2.3.0
 ```
 
 ## Usage

--- a/src/Markdown.ColorCode.CSharpToColoredHtml/Markdown.ColorCode.CSharpToColoredHtml.csproj
+++ b/src/Markdown.ColorCode.CSharpToColoredHtml/Markdown.ColorCode.CSharpToColoredHtml.csproj
@@ -7,7 +7,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>2.2.2</Version>
+		<Version>2.3.0</Version>
 		<Authors>William Baldoumas</Authors>
 		<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode, boosted with the CsharpToColouredHTML.Core package.</Description>
 		<Copyright>Copyright ©2024 William Baldoumas</Copyright>

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -1,24 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-  <ImplicitUsings>enable</ImplicitUsings>
-  <Nullable>enable</Nullable>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<GenerateDocumentationFile>True</GenerateDocumentationFile>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<Version>2.2.2</Version>
-	<Authors>William Baldoumas</Authors>
-	<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
-	<Copyright>Copyright ©2024 William Baldoumas</Copyright>
-	<PackageProjectUrl>https://wbaldoumas.github.io/markdown-colorcode/index.html</PackageProjectUrl>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<RepositoryType>git</RepositoryType>
-	<RepositoryUrl>https://github.com/wbaldoumas/markdown-colorcode</RepositoryUrl>
-	<PackageTags>markdig;markdown;html;colorcode;colorize;highlight;renderer</PackageTags>
-	<PackageLicenseFile>LICENSE</PackageLicenseFile>
-	<PackageIcon>icon.png</PackageIcon>
-	<PackageId>Markdown.ColorCode</PackageId>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <langversion>latest</langversion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Version>2.3.0</Version>
+    <Authors>William Baldoumas</Authors>
+    <Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
+    <Copyright>Copyright ©2024 William Baldoumas</Copyright>
+    <PackageProjectUrl>https://wbaldoumas.github.io/markdown-colorcode/index.html</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/wbaldoumas/markdown-colorcode</RepositoryUrl>
+    <PackageTags>markdig;markdown;html;colorcode;colorize;highlight;renderer</PackageTags>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageId>Markdown.ColorCode</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Adds support for .NET Standard 2.0 and bumps the package version to trigger a v2.3.0 release.

Closes https://github.com/wbaldoumas/markdown-colorcode/issues/149.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/markdown-colorcode/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
