### PR TITLE
v3.0.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-08-30
+
+### Changed
+
+Dependency updates:
+
+| Package | Change |
+|---|---|
+| [Markdig](https://togithub.com/lunet-io/markdig) ([source](https://togithub.com/xoofx/markdig)) | `0.40.0` -> `0.41.3` |
+| [CsharpToColouredHTML.Core](https://togithub.com/Swiftly1/CsharpToColouredHTML) | `3.0.2` -> `3.2.0` |
+
+**Notes:**
+
+- **Markdig** includes new features and fixes such as `AutoLinkOptions.AllowDomainWithoutPeriod`, perf improvements, CommonMark 0.31.2 updates, and bug fixes affecting `Markdown.ToPlainText` for code blocks and ordered list round-tripping.
+- **CsharpToColouredHTML.Core** brings improved heuristics for ValueTuples, `override`/`event` keywords, interfaces, and other cases, plus a new `"default"` color to help detect unmatched syntax during debugging.
+
 ## [3.0.0] - 2025-02-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ public interface FooService {
 ### Package Manager
 
 ```text
-Install-Package Markdown.ColorCode -Version 3.0.0
+Install-Package Markdown.ColorCode -Version 3.0.1
 ```
 
 ### .NET CLI
 
 ```text
-dotnet add package Markdown.ColorCode --version 3.0.0
+dotnet add package Markdown.ColorCode --version 3.0.1
 ```
 
 ## Usage

--- a/src/Markdown.ColorCode.CSharpToColoredHtml/Markdown.ColorCode.CSharpToColoredHtml.csproj
+++ b/src/Markdown.ColorCode.CSharpToColoredHtml/Markdown.ColorCode.CSharpToColoredHtml.csproj
@@ -7,7 +7,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<Authors>William Baldoumas</Authors>
 		<Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode, boosted with the CsharpToColouredHTML.Core package.</Description>
 		<Copyright>Copyright ©2024 William Baldoumas</Copyright>

--- a/src/Markdown.ColorCode/Markdown.ColorCode.csproj
+++ b/src/Markdown.ColorCode/Markdown.ColorCode.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>William Baldoumas</Authors>
     <Description>An extension for Markdig that adds syntax highlighting to code through the power of ColorCode.</Description>
     <Copyright>Copyright ©2024 William Baldoumas</Copyright>


### PR DESCRIPTION
This pull request updates the project to version `3.0.1`, primarily focusing on dependency upgrades and related documentation changes. The key updates are to the `Markdig` and `CsharpToColouredHTML.Core` packages, bringing in new features, performance improvements, and bug fixes. The version bump is reflected in the changelog, project files, and installation instructions.

Dependency updates:

* Upgraded `Markdig` from `0.40.0` to `0.41.3`, introducing new features (like `AutoLinkOptions.AllowDomainWithoutPeriod`), performance improvements, CommonMark 0.31.2 updates, and bug fixes for code block and ordered list handling. (`CHANGELOG.md` [CHANGELOG.mdR8-R23](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R23))
* Upgraded `CsharpToColouredHTML.Core` from `3.0.2` to `3.2.0`, improving heuristics for ValueTuples, keywords, interfaces, and adding a `"default"` color for unmatched syntax during debugging. (`CHANGELOG.md` [CHANGELOG.mdR8-R23](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R23))

Versioning and documentation:

* Updated package version to `3.0.1` in both `Markdown.ColorCode.CSharpToColoredHtml.csproj` and `Markdown.ColorCode.csproj` files. [[1]](diffhunk://#diff-c48c57466374f5df41ce4ffcdad424d55bf7d285922099e10a7e63c1c2cfeed6L10-R10) [[2]](diffhunk://#diff-08482719d8bd661c4769dcce03eaf06aa08d3e7fc54958b0eb25f06071c2278aL11-R11)
* Updated installation instructions in `README.md` to reflect the new version (`3.0.1`).